### PR TITLE
6 challenge by val with delay

### DIFF
--- a/bittbridge/base/validator.py
+++ b/bittbridge/base/validator.py
@@ -24,6 +24,7 @@ import asyncio
 import argparse
 import threading
 import bittensor as bt
+import time
 
 from typing import List, Union
 from traceback import print_exception
@@ -157,6 +158,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 self.sync()
 
                 self.step += 1
+                time.sleep(20)
 
         # If someone intentionally stops the validator, it'll safely terminate operations.
         except KeyboardInterrupt:

--- a/bittbridge/utils/timestamp.py
+++ b/bittbridge/utils/timestamp.py
@@ -1,0 +1,231 @@
+from datetime import datetime, timedelta
+from typing import Optional, Union
+
+from pytz import timezone
+
+###############################
+#           GETTERS           #
+###############################
+
+
+def get_timezone() -> timezone:
+    """
+    Set the Global shared timezone for all timestamp manipulation
+    """
+    return timezone("UTC")
+
+
+def get_now() -> datetime:
+    """
+    Get the current datetime
+    """
+    return datetime.now(get_timezone())
+
+
+def get_before(
+    timestamp: Optional[Union[datetime, str, float]] = None,
+    days: int = 0,
+    hours: int = 0,
+    minutes: int = 5,
+    seconds: int = 0,
+) -> datetime:
+    """
+    Get the datetime x minutes before now
+    """
+    if timestamp is None:
+        timestamp = get_now()
+    else:
+        timestamp = to_datetime(timestamp)
+
+    # Perform the time subtraction
+    before_timestamp = timestamp - timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+    return before_timestamp
+
+
+def get_midnight() -> datetime:
+    """
+    Get the most recent instance of midnight
+    """
+    return get_now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def get_posix() -> float:
+    """
+    Get the current POSIX time, seconds that have elapsed since Jan 1 1970
+    """
+    return to_posix(get_now())
+
+
+def get_str() -> str:
+    """
+    Get the current timestamp as a string, convenient for requests
+    """
+    return to_str(get_now())
+
+
+###############################
+#         CONVERTERS          #
+###############################
+
+
+def to_posix(timestamp: Union[datetime, str, float]) -> float:
+    """
+    Convert datetime to seconds that have elapsed since Jan 1 1970
+    """
+
+    # Verify datetime object and convert to UTC
+    utc_datetime = to_datetime(timestamp)
+
+    # Convert to posix time float
+    posix_timestamp = utc_datetime.timestamp()
+
+    return float(posix_timestamp)
+
+
+def to_str(timestamp: Union[datetime, str, float]) -> str:
+    """
+    Convert datetime to iso 8601 string
+    """
+
+    # Verify datetime object and convert to UTC
+    utc_datetime = to_datetime(timestamp)
+
+    # Convert to iso8601 string
+    str_datetime = utc_datetime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    return str(str_datetime)
+
+
+def to_datetime(timestamp: Union[str, float]) -> datetime:
+    """
+    Convert iso 8601 string, or a POSIX time float, to datetime
+    """
+    if isinstance(timestamp, str):
+        # Assume the proper iso 8601 string format is used
+        # `strptime` will trigger an error as needed
+        return datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=get_timezone())
+
+    elif isinstance(timestamp, float):
+        # Assume proper float value
+        # `fromtimestamp` will trigger errors as needed
+        return datetime.fromtimestamp(timestamp, tz=get_timezone())
+
+    elif isinstance(timestamp, datetime):
+        # Already a datetime object
+        # Return as UTC
+        return timestamp.astimezone(get_timezone())
+
+    else:
+        # Invalid typing
+        raise TypeError(
+            "Must pass a timestamp that is either a iso 8601 string, POSIX time float, or a datetime object"
+        )
+
+
+###############################
+#          FUNCTIONS          #
+###############################
+
+
+def elapsed_seconds(timestamp1: datetime, timestamp2: datetime) -> float:
+    """
+    Absolute number of seconds between two timestamps
+    """
+    return abs((timestamp1 - timestamp2).total_seconds())
+
+
+def round_minute_down(timestamp: datetime, base: int = 5) -> datetime:
+    """
+    Round the timestamp down to the nearest 5 minutes
+
+    Example:
+        >>> timestamp = datetime.now(timezone("UTC"))
+        >>> timestamp
+        datetime.datetime(2024, 11, 14, 18, 18, 16, 719482, tzinfo=<UTC>)
+        >>> round_minute_down(timestamp)
+        datetime.datetime(2024, 11, 14, 18, 15, tzinfo=<UTC>)
+    """
+    # Round the minute down to the nearest multiple of `base`
+    correct_minute: int = timestamp.minute // base * base
+    return timestamp.replace(minute=correct_minute, second=0, microsecond=0)
+
+
+def round_to_interval(timestamp: datetime, interval_minutes: int = 5) -> datetime:
+    """
+    Round a timestamp to the nearest interval (up or down).
+
+    Args:
+        timestamp (datetime): The timestamp to round
+        interval_minutes (int): The interval in minutes to round to. Defaults to 5.
+
+    Returns:
+        datetime: A new timestamp rounded to the nearest interval
+
+    Example:
+        >>> dt = datetime(2024, 1, 1, 14, 13, 30, tzinfo=timezone('UTC'))
+        >>> round_to_interval(dt, 5)
+        datetime.datetime(2024, 1, 1, 14, 15, tzinfo=<UTC>)  # Rounds up to 14:15
+        >>> round_to_interval(dt, 15)
+        datetime.datetime(2024, 1, 1, 14, 15, tzinfo=<UTC>)  # Rounds up to 14:15
+        >>> dt = datetime(2024, 1, 1, 14, 16, 30, tzinfo=timezone('UTC'))
+        >>> round_to_interval(dt, 15)
+        datetime.datetime(2024, 1, 1, 14, 15, tzinfo=<UTC>)  # Rounds down to 14:15
+    """
+    if not isinstance(timestamp, datetime):
+        timestamp = to_datetime(timestamp)
+
+    # Ensure timestamp is in UTC
+    utc_timestamp = timestamp.astimezone(get_timezone())
+
+    # Calculate total minutes since midnight
+    minutes_since_midnight = utc_timestamp.hour * 60 + utc_timestamp.minute
+
+    # Calculate the nearest interval
+    rounded_minutes = round(minutes_since_midnight / interval_minutes) * interval_minutes
+
+    # Create new timestamp with rounded minutes
+    new_timestamp = utc_timestamp.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(
+        minutes=rounded_minutes
+    )
+
+    return new_timestamp
+
+
+def is_query_time(prediction_interval: int, timestamp: str, tolerance: int = 120) -> bool:
+    """
+    Tolerance - in seconds, how long to allow after epoch start
+    prediction_interval - in minutes, how often to predict
+
+    Notes:
+        This function will be called multiple times
+        First, check that we are in a new epoch
+        Then, check if we already sent a request in the current epoch
+    """
+    now: datetime = get_now()
+    provided_timestamp: datetime = to_datetime(timestamp)
+
+    # The provided timestamp is the last time a request was made. If this timestamp
+    # is from the current epoch, we do not want to make a request. One way to check
+    # this is by checking that `now` and `provided_timestamp` are more than `tolerance`
+    # apart from each other. When true, this means the `provided_timestamp` is from
+    # the previous epoch
+    been_long_enough = elapsed_seconds(now, provided_timestamp) > tolerance
+
+    # return false early if we already know it has not been long enough
+    if not been_long_enough:
+        return False
+
+    # If it has been long enough, let's check the epoch start time
+    midnight = get_midnight()
+    sec_since_open = elapsed_seconds(now, midnight)
+
+    # To check if this is a new epoch, compare the current timestamp
+    # to the expected beginning of an epoch. If we are within `tolerance`
+    # seconds of a new epoch, then we are willing to send a request
+    sec_since_epoch_start = sec_since_open % (prediction_interval * 60)
+    beginning_of_epoch = sec_since_epoch_start < tolerance
+
+    # We know a request hasn't been sent yet, so simply return T/F based
+    # on beginning of epoch
+    return beginning_of_epoch

--- a/bittbridge/validator/forward.py
+++ b/bittbridge/validator/forward.py
@@ -18,8 +18,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 import time
-from datetime import datetime
-
+from datetime import datetime, timezone
 import bittensor as bt
 from bittbridge.protocol import Challenge
 from bittbridge.validator.reward import get_rewards
@@ -37,7 +36,7 @@ async def forward(self):
     5. Update miner scores.
     """
     # Step 1: Generate timestamp
-    timestamp = datetime.now(datetime.UTC).isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()
 
     # Step 2: Select miners (k comes from self.config.neuron.sample_size)
     miner_uids = get_random_uids(self, k=self.config.neuron.sample_size)
@@ -59,9 +58,9 @@ async def forward(self):
     for i, response in enumerate(responses):
         bt.logging.info(f"[RESPONSE {i}] UID={miner_uids[i]}, Prediction={response.prediction}, Interval={response.interval}")
 
-    # Step 5: Score responses (immediate scoring for now)
+    # Step 5: Score responses
+    bt.logging.debug(f"Calculating rewards for timestamp: {timestamp}")
     rewards = get_rewards(self, timestamp, responses)
 
     # Step 6: Update scores
     self.update_scores(rewards, miner_uids)
-    time.sleep(5)

--- a/bittbridge/validator/forward.py
+++ b/bittbridge/validator/forward.py
@@ -35,9 +35,6 @@ async def forward(self):
     3. Build a Challenge synapse with the timestamp
     4. Query miners
     5. Store responses and timestamp
-    6. Wait for a minute before evaluating miner predictions
-    7. Score responses based on how close predictions are to the current price. 
-    8. Update miner scores
     """
     # Step 1: Generate timestamp
     timestamp = datetime.now(timezone.utc).isoformat()

--- a/bittbridge/validator/forward.py
+++ b/bittbridge/validator/forward.py
@@ -22,7 +22,6 @@ import asyncio
 from datetime import datetime, timezone
 import bittensor as bt
 from bittbridge.protocol import Challenge
-from bittbridge.validator.reward import get_rewards
 from bittbridge.utils.uids import get_random_uids
 
 

--- a/bittbridge/validator/forward.py
+++ b/bittbridge/validator/forward.py
@@ -56,27 +56,28 @@ async def forward(self):
         deserialize=False
     )
     
-    # Step 5: Store responses and timestamp
-    pending_evaluation = {
-        "timestamp": timestamp,
-        "responses": responses,
-        "miner_uids": miner_uids
-    }
-    # -------------------------------------
-
-    bt.logging.info(f"[VALIDATOR] Queried miners: {[uid for uid in miner_uids]}")
-    bt.logging.info(f"[VALIDATOR] Received {len(responses)} responses")
-
+    # Step 5: Store predictions in queue
+    now = time.time()
     for i, response in enumerate(responses):
-        bt.logging.info(f"[RESPONSE {i}] UID={miner_uids[i]}, Prediction={response.prediction}, Interval={response.interval}")
+        self.prediction_queue.append({
+            "timestamp": timestamp,
+            "miner_uid": miner_uids[i],
+            "prediction": response.prediction,
+            "interval": response.interval,
+            "request_time": now
+        })
+        bt.logging.info(f"[COLLECT] UID={miner_uids[i]}, Prediction={response.prediction}, Interval={response.interval}")
+        
+    # bt.logging.info(f"[VALIDATOR] Queried miners: {[uid for uid in miner_uids]}")
+    # bt.logging.info(f"[VALIDATOR] Received {len(responses)} responses")
 
-    # Step 6: Wait before evaluating
-    bt.logging.info("Waiting 1 minute before evaluating miner predictions...")
-    await asyncio.sleep(60)
+    # # Step 6: Wait before evaluating
+    # bt.logging.info("Waiting 1 minute before evaluating miner predictions...")
+    # await asyncio.sleep(60)
 
-    # Step 7: Score responses
-    bt.logging.debug(f"Calculating rewards for timestamp: {pending_evaluation['timestamp']}")
-    rewards = get_rewards(self, pending_evaluation["timestamp"], pending_evaluation["responses"])
+    # # Step 7: Score responses
+    # bt.logging.debug(f"Calculating rewards for timestamp: {pending_evaluation['timestamp']}")
+    # rewards = get_rewards(self, pending_evaluation["timestamp"], pending_evaluation["responses"])
 
-    # Step 8: Update scores
-    self.update_scores(rewards, pending_evaluation["miner_uids"])
+    # # Step 8: Update scores
+    # self.update_scores(rewards, pending_evaluation["miner_uids"])

--- a/bittbridge/validator/reward.py
+++ b/bittbridge/validator/reward.py
@@ -51,22 +51,22 @@ def reward(actual_price: float, predicted_price: float) -> float:
     return reward_val
 
 
-def get_rewards(self, query, responses: List[Challenge]) -> np.ndarray:
-    """
-    Generate a reward for each miner response to the Challenge synapse.
+# def get_rewards(self, query, responses: List[Challenge]) -> np.ndarray:
+#     """
+#     Generate a reward for each miner response to the Challenge synapse.
 
-    Args:
-        query: Placeholder for future use (e.g., timestamp)
-        responses: List of Challenge synapse responses from miners
+#     Args:
+#         query: Placeholder for future use (e.g., timestamp)
+#         responses: List of Challenge synapse responses from miners
 
-    Returns:
-        np.ndarray of reward floats
-    """
-    actual_price = get_actual_usdt_cny()
-    if actual_price is None:
-        return np.zeros(len(responses))  # No rewards if we can’t validate
+#     Returns:
+#         np.ndarray of reward floats
+#     """
+#     actual_price = get_actual_usdt_cny()
+#     if actual_price is None:
+#         return np.zeros(len(responses))  # No rewards if we can’t validate
 
-    return np.array([
-        reward(actual_price, synapse.prediction) if synapse.prediction is not None else 0.0
-        for synapse in responses
-    ])
+#     return np.array([
+#         reward(actual_price, synapse.prediction) if synapse.prediction is not None else 0.0
+#         for synapse in responses
+#     ])

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -62,16 +62,16 @@ class Validator(BaseValidatorNeuron):
             await asyncio.sleep(check_interval)
 
 
-async def main():
-    with Validator() as validator:
-        async def prediction_scheduler():
-            while True:
-                await validator.forward()
-                await asyncio.sleep(30)  # 30 seconds between predictions
+async def prediction_scheduler(validator):
+    while True:
+        await validator.forward()
+        await asyncio.sleep(30)  # 30 seconds between predictions
 
-        eval_task = asyncio.create_task(validator.evaluation_loop(evaluation_delay=60, check_interval=5))
-        pred_task = asyncio.create_task(prediction_scheduler())
-        await asyncio.gather(eval_task, pred_task)
+async def main():
+    validator = Validator()
+    eval_task = asyncio.create_task(validator.evaluation_loop(evaluation_delay=60, check_interval=5))
+    pred_task = asyncio.create_task(prediction_scheduler(validator))
+    await asyncio.gather(eval_task, pred_task)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -52,5 +52,4 @@ class Validator(BaseValidatorNeuron):
 if __name__ == "__main__":
     with Validator() as validator:
         while True:
-            bt.logging.info(f"Validator running... {time.time()}")
-            time.sleep(5)
+            pass


### PR DESCRIPTION
## Dev Report - validator changes
**Files Changed:** `forward.py`, `validator.py`, `protocol.py`
**File added:** `timestamp.py`


---
### 1. Hotfix: Type in `deserialize()`
- **Changed:** `deserialize(self) -> int` → `deserialize(self) -> float`
- **Why:** Ensures correct type inference for predicted float values.
- **File:** `protocol.py`
---
### 2. Basic delay between validator cycles
- **Added:** `time.sleep(20)` inside validator run loop (`base/validator.py`) to prevent tight spinning.
- **Minor Tweaks:** Timezone fix with `datetime.now(timezone.utc)`
- **Files:** `base/validator.py`, `forward.py`, `neurons/validator.py`
---
### 3. Delayed miner evaluation mechanism
- **Added:**
  - Store miner responses in a `pending_evaluation` object.
  - Introduced a `1-minute delay` before scoring predictions.
- **Logic:** After querying miners → wait → evaluate predictions → update scores.
- **File:** `forward.py`
---
### 4. Validator prediction & evaluation decoupling (async)
- **Introduced:** Parallel async architecture (inspired by precog solution) for:
  - `prediction_scheduler()` → sends challenges every 30s
  - `evaluation_loop()` → evaluates predictions after a delay 60s
- **Key Features:**
  - Prediction queue added to `Validator` class.
  - Actual price fetched with `get_actual_usdt_cny()`.
  - Rewards calculated and scores updated individually.
- **Impact:** Separation of concerns, improved validator design for scalability.
- **Files:** `neurons/validator.py`, `forward.py`

---

### 📌 Next Steps Done
---
**Summary Table done**
# 1
The `is_query_time()` function ensures validators across the network all query at the same standardized timestamps, creating consistent evaluation windows.

- **Epoch-based querying:** Instead of sending queries at a fixed interval (e.g., every 30 seconds), now sends queries at the start of each "epoch" (e.g., every N minutes, aligned to the clock).
- **Timestamp logic:** Uses utility functions (`is_query_time`, `round_to_interval`, etc.) to determine if it's time to send a query, based on the current time and the last query timestamp.
- **Tolerance window:** Allows a small window (e.g., 120 seconds) after the epoch starts to send the query, so the validator doesn't miss the epoch if it's a bit late.
- **Stateful scheduling:** Keeps track of the last query timestamp and only sends a new query if enough time has passed and it's the start of a new epoch.
- **Cons:** Queries are aligned to real-world time epochs, which is more predictable and fair for miners, and avoids duplicate queries in the same epoch. And avoids over-querying or missing epochs.

| №   | Features to add (precog reference) | Status | What to Add/Change                   |
| --- | ---------------------------------- | ------ | ------------------------------------ |
| 1   | Epoch-based query scheduling       | ✅      | Use timestamp logic, `is_query_time` |
| 2   | Miner availability filtering       | ✅      | Implement `get_available_uids`       |
| 5   | State management                   | 🔄     | Save/load moving averages/history    |
| 6   | Async task scheduling              | 🔄     | Use multiple scheduled tasks         |
| 7   | Don't see miner with other port    | ✅      | use axon.ip & port other ones        |
| 8   | Resync_metagrapg                   | ✅      | Resync_metagrapg                     |
| 9   | Remove API keys & clean code       | 🔄     |                                      |
